### PR TITLE
Add doctrine deleted objects to objects staged for flush

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Deleted objects will now trigger PostPersistDomainRule like insertions & updates
 
 ## [2.1.4] - 2020-09-01
 ### Fixed

--- a/Tests/PostPersistListener/DoctrinePostPersistListenerTest.php
+++ b/Tests/PostPersistListener/DoctrinePostPersistListenerTest.php
@@ -25,6 +25,7 @@ class DoctrinePostPersistListenerTest extends TestCase
         $unitOfWork = $this->prophesize(UnitOfWork::class);
         $unitOfWork->getScheduledEntityInsertions()->willReturn([$model]);
         $unitOfWork->getScheduledEntityUpdates()->willReturn([]);
+        $unitOfWork->getScheduledEntityDeletions()->willReturn([]);
         $entityManager = $this->prophesize(EntityManager::class);
         $entityManager->getUnitOfWork()->willReturn($unitOfWork->reveal());
         $onFlushEvent = $this->prophesize(OnFlushEventArgs::class);

--- a/src/PostPersistListener/DoctrinePostPersistListener.php
+++ b/src/PostPersistListener/DoctrinePostPersistListener.php
@@ -54,6 +54,12 @@ class DoctrinePostPersistListener extends AbstractBridgeListener implements Even
                 $this->modelsStageForFlush[] = $entity;
             }
         }
+
+        foreach ($unitOfWork->getScheduledEntityDeletions() as $entity) {
+            if ($entity instanceof ModelInterface) {
+                $this->modelsStageForFlush[] = $entity;
+            }
+        }
     }
 
     /**


### PR DESCRIPTION
While this change may seems strange, there's no way for now to make a deleted entity to throw a PostPersistDomainRule.

This is useful when managing a collection of objects as property of an other object.