### PR TITLE
Fix return type deprecation notice of Symfony

### DIFF
--- a/src/Integration/Symfony/DomainBundle.php
+++ b/src/Integration/Symfony/DomainBundle.php
@@ -2,6 +2,7 @@
 
 namespace Biig\Component\Domain\Integration\Symfony;
 
+use Symfony\Component\DependencyInjection\Extension\ExtensionInterface;
 use Biig\Component\Domain\Integration\Symfony\DependencyInjection\CompilerPass\EnableDomainDenormalizerCompilerPass;
 use Biig\Component\Domain\Integration\Symfony\DependencyInjection\CompilerPass\InsertDispatcherInClassMetadataFactoryCompilerPass;
 use Biig\Component\Domain\Integration\Symfony\DependencyInjection\CompilerPass\RegisterDomainRulesCompilerPass;
@@ -15,7 +16,7 @@ class DomainBundle extends Bundle
     /**
      * {@inheritdoc}
      */
-    public function getContainerExtension()
+    public function getContainerExtension(): ?ExtensionInterface
     {
         return new DomainExtension();
     }


### PR DESCRIPTION
Merging this requires an upgrade of the PHP minimum version: https://github.com/swagindustries/doctrine-domain-events/blob/d7acc29849fb46e96d92324f1c3651e747e889de/composer.json#L6