### PR TITLE
:white_check_mark: Fix test suite

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,8 @@
         "phpunit/phpunit": "^8.5",
         "doctrine/orm": "^2.6.3",
         "friendsofphp/php-cs-fixer": "^2.14",
-        "symfony/symfony": "^4.3 || ^5.0"
+        "symfony/symfony": "^4.3 || ^5.0",
+        "phpspec/prophecy-phpunit": "^1.0"
     },
     "conflict": {
         "doctrine/orm": "<2.6.3"


### PR DESCRIPTION
It is required to pass the test suite since since we use the method `prophesize()`.

See https://github.com/swagindustries/doctrine-domain-events/runs/8240117535?check_suite_focus=true