### PR TITLE
:arrow_up: Add support to Sf 6.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
     "license": "MIT",
     "require": {
         "php": ">=7.4",
-        "symfony/event-dispatcher": "^4.3|^5.0",
+        "symfony/event-dispatcher": "^4.3|^5.0|^6.0",
         "doctrine/doctrine-bundle": "^1.8|^2.0",
         "doctrine/orm": "^2.6.3"
     },
@@ -18,7 +18,7 @@
         "phpunit/phpunit": "^8.5",
         "doctrine/orm": "^2.6.3",
         "friendsofphp/php-cs-fixer": "^2.14",
-        "symfony/symfony": "^4.3 || ^5.0",
+        "symfony/symfony": "^4.3 || ^5.0 || ^6.0",
         "phpspec/prophecy-phpunit": "^1.0"
     },
     "conflict": {


### PR DESCRIPTION
Replace #11 without removing Sf 4.4 compatibility. It seems that no code change is required.