### PR TITLE
:coffin: Remove previously deprecated code

### DIFF
--- a/Tests/Event/DomainEventTest.php
+++ b/Tests/Event/DomainEventTest.php
@@ -29,10 +29,4 @@ class DomainEventTest extends TestCase
         $event->setDelayed();
         $this->assertTrue($event->isDelayed());
     }
-
-    public function testItThrowsAnErrorIfOrignalEventIsNotAnEvent()
-    {
-        $this->expectException(InvalidArgumentException::class);
-        $event = new DomainEvent(null, [], 'foo');
-    }
 }

--- a/src/Debug/TraceableDomainEventDispatcher.php
+++ b/src/Debug/TraceableDomainEventDispatcher.php
@@ -10,10 +10,9 @@ use Biig\Component\Domain\Rule\PostPersistDomainRuleInterface;
 use Psr\Log\NullLogger;
 use Symfony\Component\EventDispatcher\Debug\TraceableEventDispatcher;
 use Symfony\Component\EventDispatcher\Event;
-use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\Stopwatch\Stopwatch;
 
-abstract class AbstractTraceableDomainEventDispatcher extends TraceableEventDispatcher implements DomainEventDispatcherInterface
+class TraceableDomainEventDispatcher extends TraceableEventDispatcher implements DomainEventDispatcherInterface
 {
     /**
      * @var array
@@ -89,61 +88,21 @@ abstract class AbstractTraceableDomainEventDispatcher extends TraceableEventDisp
     {
         return $this->delayedListenersCalled;
     }
-}
-if (method_exists(TraceableEventDispatcher::class, 'preDispatch')) {
-    // BC Layer for Sf 4.3 & 4.4
-    class TraceableDomainEventDispatcher extends AbstractTraceableDomainEventDispatcher
+
+    /**
+     * Dispatches an event to all registered listeners.
+     *
+     * @param object      $event     The event to pass to the event handlers/listeners
+     * @param string|null $eventName The name of the event to dispatch. If not supplied,
+     *                               the class of $event should be used instead.
+     *
+     * @return object The passed $event MUST be returned
+     */
+    public function dispatch(object $event, string $eventName = null): object
     {
-        /**
-         * Dispatches an event to all registered listeners.
-         *
-         * @param object      $event     The event to pass to the event handlers/listeners
-         * @param string|null $eventName The name of the event to dispatch. If not supplied,
-         *                               the class of $event should be used instead.
-         *
-         * @return object The passed $event MUST be returned
-         */
-        public function dispatch($event /* , string $eventName = null */) // Compatibility layer with Sf 4.3 & 4.4
-        {
-            $eventName = 1 < \func_num_args() ? func_get_arg(1) : null;
+        $eventName = $eventName ?? get_class($event);
+        $this->eventsFired[] = $eventName;
 
-            if (\is_object($event)) {
-                $eventName = $eventName ?? \get_class($event);
-            } else {
-                @trigger_error(sprintf('Calling the "%s::dispatch()" method with the event name as first argument is deprecated since Symfony 4.3, pass it second and provide the event object first instead.', EventDispatcherInterface::class), E_USER_DEPRECATED);
-                $swap = $event;
-                $event = $eventName ?? new Event();
-                $eventName = $swap;
-
-                if (!$event instanceof Event) {
-                    throw new \TypeError(sprintf('Argument 1 passed to "%s::dispatch()" must be an instance of "%s", "%s" given.', EventDispatcherInterface::class, Event::class, \is_object($event) ? \get_class($event) : \gettype($event)));
-                }
-            }
-
-            $eventName = $eventName ?? get_class($event);
-            $this->eventsFired[] = $eventName;
-
-            return parent::dispatch($event, $eventName);
-        }
-    }
-} else {
-    class TraceableDomainEventDispatcher extends AbstractTraceableDomainEventDispatcher
-    {
-        /**
-         * Dispatches an event to all registered listeners.
-         *
-         * @param object      $event     The event to pass to the event handlers/listeners
-         * @param string|null $eventName The name of the event to dispatch. If not supplied,
-         *                               the class of $event should be used instead.
-         *
-         * @return object The passed $event MUST be returned
-         */
-        public function dispatch(object $event, string $eventName = null): object
-        {
-            $eventName = $eventName ?? get_class($event);
-            $this->eventsFired[] = $eventName;
-
-            return parent::dispatch($event, $eventName);
-        }
+        return parent::dispatch($event, $eventName);
     }
 }

--- a/src/Event/DomainEvent.php
+++ b/src/Event/DomainEvent.php
@@ -2,48 +2,31 @@
 
 namespace Biig\Component\Domain\Event;
 
-use Biig\Component\Domain\Exception\InvalidArgumentException;
 use Symfony\Component\EventDispatcher\GenericEvent;
+use Symfony\Contracts\EventDispatcher\Event;
 
 class DomainEvent extends GenericEvent
 {
-    /**
-     * @var \Symfony\Component\EventDispatcher\Event|\Symfony\Contracts\EventDispatcher\Event|null
-     */
-    private $originalEvent;
+    private ?Event $originalEvent;
 
     /**
      * If true, it will be raised after doctrine flush.
-     *
-     * @var bool
      */
-    private $delayed;
+    private bool $delayed;
 
-    public function __construct($subject = null, $arguments = [], /* Event */ $originalEvent = null)
+    public function __construct($subject = null, $arguments = [], Event $originalEvent = null)
     {
-        // BC layer for Symfony 4.3
-        if (!\is_null($originalEvent) &&
-            !((class_exists(\Symfony\Component\EventDispatcher\Event::class) && $originalEvent instanceof \Symfony\Component\EventDispatcher\Event)
-            || (class_exists(\Symfony\Contracts\EventDispatcher\Event::class) && $originalEvent instanceof \Symfony\Contracts\EventDispatcher\Event)
-            )
-        ) {
-            throw new InvalidArgumentException('The orignal event must be an instance of Symfony Events');
-        }
-
         parent::__construct($subject, $arguments);
         $this->originalEvent = $originalEvent;
         $this->delayed = false;
     }
 
-    /**
-     * @return \Symfony\Component\EventDispatcher\Event|\Symfony\Contracts\EventDispatcher\Event|null
-     */
-    public function getOriginalEvent()
+    public function getOriginalEvent(): ?Event
     {
         return $this->originalEvent;
     }
 
-    public function isDelayed()
+    public function isDelayed(): bool
     {
         return $this->delayed;
     }


### PR DESCRIPTION
Compatibility with Symfony 6 came with Sf 4.4 compatibility removal. All the backward compatibility layers can now be removed! 🎉 