### PR TITLE
fix(serialization): ignore dispatcher on DomainModelTrait

### DIFF
--- a/src/Model/DomainModelTrait.php
+++ b/src/Model/DomainModelTrait.php
@@ -4,12 +4,14 @@ namespace Biig\Component\Domain\Model;
 
 use Biig\Component\Domain\Event\DomainEvent;
 use Biig\Component\Domain\Event\DomainEventDispatcherInterface;
+use Symfony\Component\Serializer\Annotation\Ignore;
 
 trait DomainModelTrait
 {
     /**
      * @var DomainEventDispatcherInterface
      */
+    #[Ignore]
     private $dispatcher;
 
     /**


### PR DESCRIPTION
ApiPlateform were trying to serialize dispatcher from DomainModelTrait.