### PR TITLE
:bug: Fix dev helper too strict

### DIFF
--- a/Tests/PostFlushListener/EntitiesHasDispatcherCheckerTest.php
+++ b/Tests/PostFlushListener/EntitiesHasDispatcherCheckerTest.php
@@ -14,6 +14,7 @@ use Biig\Component\Domain\Tests\Model\FakeDomainEventDispatcher;
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\Event\PostFlushEventArgs;
 use Doctrine\ORM\Mapping\ClassMetadata;
+use Doctrine\ORM\Proxy\Proxy;
 use Doctrine\ORM\UnitOfWork;
 use Prophecy\Argument;
 use Prophecy\PhpUnit\ProphecyTrait;
@@ -125,6 +126,18 @@ class EntitiesHasDispatcherCheckerTest extends KernelTestCase
         $subject = new EntitiesHasDispatcherChecker();
         $subject->postFlush($this->mockEvent([
             'someFqcn' => [getComplexModel(),],
+        ]));
+    }
+
+    public function testItDoesNothingWhenAProxyIsGiven()
+    {
+        $proxy = $this->prophesize(Proxy::class)->reveal();
+        $subject = new EntitiesHasDispatcherChecker();
+
+        $this->entityManger->getClassMetadata(Argument::cetera())->shouldNotBeCalled();
+
+        $subject->postFlush($this->mockEvent([
+            'someFqcn' => [$proxy],
         ]));
     }
 

--- a/src/Integration/Symfony/DependencyInjection/CompilerPass/VerifyDoctrineConfigurationCompilerPass.php
+++ b/src/Integration/Symfony/DependencyInjection/CompilerPass/VerifyDoctrineConfigurationCompilerPass.php
@@ -35,7 +35,7 @@ class VerifyDoctrineConfigurationCompilerPass implements CompilerPassInterface
         foreach ($calls as $call) {
             if ('setClassMetadataFactoryName' === $call[0]) {
                 if (ClassMetadataFactory::class !== $call[1][0]) {
-                    throw new InvalidConfigurationException('The option "override_doctrine_instantiator", so this bundles tried to change the' . ' ClassMetadataFactory of doctrine by changing the DoctrineBundle configuration.' . ' The final configuration of the doctrine bundle doesn\'t looks like the one expected:' . ' Something probably altered the configuration. You may disable this feature by changing the default' . ' configuration or find what came override this. (It may be your manual configuration)');
+                    throw new InvalidConfigurationException('The option "override_doctrine_instantiator", so this bundles tried to change the ClassMetadataFactory of doctrine by changing the DoctrineBundle configuration. The final configuration of the doctrine bundle doesn\'t looks like the one expected: Something probably altered the configuration. You may disable this feature by changing the default configuration or find what came override this. (It may be your manual configuration)');
                 }
             }
         }

--- a/src/PostFlushListener/EntitiesHasDispatcherChecker.php
+++ b/src/PostFlushListener/EntitiesHasDispatcherChecker.php
@@ -10,6 +10,7 @@ use Biig\Component\Domain\Exception\InvalidArgumentException;
 use Biig\Component\Domain\Model\ModelInterface;
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\Event\PostFlushEventArgs;
+use Doctrine\ORM\Proxy\Proxy;
 
 final class EntitiesHasDispatcherChecker
 {
@@ -27,7 +28,7 @@ final class EntitiesHasDispatcherChecker
 
     private function checkModelEntityHasDispatcher(object $entity, EntityManagerInterface $entityManager): void
     {
-        if (!$entity instanceof ModelInterface) {
+        if (!$entity instanceof ModelInterface || $entity instanceof Proxy) {
             return;
         }
 


### PR DESCRIPTION
## Context

The PR #8 came with a nice new feature that prevents mistakes in the development environment; but the check was also processed against proxies, leading to weird errors sometimes. This is why I suggest to not check against proxies.