### PR TITLE
:sparkles: Add (new) context option to denormalizer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+- Add new return types (for Symfony 6)
+- Add new context parameter for DomainDenormalizer
+
 ## [2.3.2] - 2023-03-15
 
 ### Fixed

--- a/src/Integration/Symfony/Serializer/DomainDenormalizer.php
+++ b/src/Integration/Symfony/Serializer/DomainDenormalizer.php
@@ -50,9 +50,9 @@ final class DomainDenormalizer implements NormalizerInterface, DenormalizerInter
     /**
      * {@inheritdoc}
      */
-    public function supportsDenormalization($data, $type, $format = null): bool
+    public function supportsDenormalization($data, $type, $format = null, array $context = []): bool
     {
-        return $this->decorated->supportsDenormalization($data, $type, $format);
+        return $this->decorated->supportsDenormalization($data, $type, $format, $context);
     }
 
     /**
@@ -67,9 +67,9 @@ final class DomainDenormalizer implements NormalizerInterface, DenormalizerInter
     /**
      * {@inheritdoc}
      */
-    public function supportsNormalization($data, $format = null): bool
+    public function supportsNormalization($data, $format = null, array $context = []): bool
     {
-        return $this->decorated->supportsNormalization($data, $format);
+        return $this->decorated->supportsNormalization($data, $format, $context);
     }
 
     public function setSerializer(SerializerInterface $serializer): void


### PR DESCRIPTION
Side note: it does not implement ContextAware interfaces because they are deprecated in Symfony 6.1 and will be removed in 7.0