### PR TITLE
Update Symfony minimum version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [3.1.0] - 2024-08-06
+
+### Added
+
+- Compatibility with Symfony 7.0+
+
+### Removed
+
+- Compatibility with Symfony 5.x
+
 ## [3.0.0] - 2024-08-01
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ Versions
 |---------|--------------|---------------|-----------------|-------------|---------------------------------|
 | 1.x     | Unmaintained | [v1][v1-doc]  | >= 3.3 && <5    | >= 7.1      |                                 |
 | 2.x     | Maintained   | [v2][v2-doc]  | >= 4.3          | >= 7.4      |                                 |
-| 3.x     | Latest       | [v3][v3-doc]  | >= 5.4          | >= 8.1      | See [UPGRADE](v3-upgrade) guide |
+| 3.x     | Latest       | [v3][v3-doc]  | >= 6.4          | >= 8.1      | See [UPGRADE](v3-upgrade) guide |
 
 [v1-doc]: https://github.com/swagindustries/doctrine-domain-events/tree/v1.5.2/docs
 [v2-doc]: https://github.com/swagindustries/doctrine-domain-events/tree/v2.3.3/docs

--- a/Tests/Symfony/Serializer/DomainDenormalizerTest.php
+++ b/Tests/Symfony/Serializer/DomainDenormalizerTest.php
@@ -8,8 +8,10 @@ use Biig\Component\Domain\Integration\Symfony\Serializer\DomainDenormalizer;
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
 use Prophecy\PhpUnit\ProphecyTrait;
+use Prophecy\Prophecy\ObjectProphecy;
 use Symfony\Component\Serializer\Normalizer\CacheableSupportsMethodInterface;
 use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
 use Symfony\Component\Serializer\Normalizer\ObjectNormalizer;
 
 class DomainDenormalizerTest extends TestCase
@@ -17,7 +19,7 @@ class DomainDenormalizerTest extends TestCase
     use ProphecyTrait;
 
     /**
-     * @var ObjectNormalizer
+     * @var ObjectNormalizer|ObjectProphecy
      */
     private $decorated;
 
@@ -28,7 +30,8 @@ class DomainDenormalizerTest extends TestCase
 
     public function setUp(): void
     {
-        $this->decorated = $this->prophesize(ObjectNormalizer::class);
+        $this->decorated = $this->prophesize(NormalizerInterface::class);
+        $this->decorated->willImplement(DenormalizerInterface::class);
         $this->dispatcher = new DomainEventDispatcher();
     }
 
@@ -65,12 +68,5 @@ class DomainDenormalizerTest extends TestCase
 
         $denormalizer = new DomainDenormalizer($this->decorated->reveal(), $this->dispatcher);
         $denormalizer->denormalize([], FakeModel::class, null, []);
-    }
-
-    public function testItIsAnInstanceOfCacheableSupportsMethodInterface()
-    {
-        $denormalizer = new DomainDenormalizer($this->decorated->reveal(), $this->dispatcher);
-        $this->assertInstanceOf(CacheableSupportsMethodInterface::class, $denormalizer);
-        $this->assertTrue($denormalizer->hasCacheableSupportsMethod());
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
     "license": "MIT",
     "require": {
         "php": ">=8.1",
-        "symfony/event-dispatcher": "^5.4|^6.0|^7.0",
+        "symfony/event-dispatcher": "^6.4|^7.0",
         "doctrine/doctrine-bundle": "^1.8|^2.0",
         "doctrine/orm": "^2.18.3|^3.0"
     },
@@ -18,16 +18,16 @@
         "phpunit/phpunit": "^9.5 || ^10",
         "doctrine/orm": "^2.18.3",
         "friendsofphp/php-cs-fixer": "^3.49.0",
-        "symfony/framework-bundle": "^5.0 || ^6.0",
+        "symfony/framework-bundle": "^6.4 || ^7.0",
         "phpspec/prophecy-phpunit": "^2.0.1",
         "monolog/monolog": "^2.8.0 || ^3.2.0",
-        "symfony/var-dumper": "^5.0 || ^6.0",
-        "symfony/serializer": "^5.0 || ^6.0",
-        "symfony/asset": "^5.0 || ^6.0",
-        "symfony/form": "^5.0 || ^6.0",
-        "symfony/property-access": "^5.0 || ^6.0",
+        "symfony/var-dumper": "^6.4 || ^7.0",
+        "symfony/serializer": "^6.4 || ^7.0",
+        "symfony/asset": "^6.4 || ^7.0",
+        "symfony/form": "^6.4 || ^7.0",
+        "symfony/property-access": "^6.4 || ^7.0",
         "symfony/debug-pack": "^1.0",
-        "symfony/yaml": "^5.0 || ^6.0"
+        "symfony/yaml": "^6.4 || ^7.0"
     },
     "conflict": {
         "doctrine/orm": "<2.6.3"

--- a/src/Integration/Symfony/Serializer/DomainDenormalizer.php
+++ b/src/Integration/Symfony/Serializer/DomainDenormalizer.php
@@ -4,7 +4,6 @@ namespace Biig\Component\Domain\Integration\Symfony\Serializer;
 
 use Biig\Component\Domain\Event\DomainEventDispatcherInterface;
 use Biig\Component\Domain\Model\ModelInterface;
-use Symfony\Component\Serializer\Normalizer\CacheableSupportsMethodInterface;
 use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
 use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
 use Symfony\Component\Serializer\Normalizer\ObjectNormalizer;
@@ -14,7 +13,7 @@ use Symfony\Component\Serializer\SerializerInterface;
 /**
  * Class DomainDenormalizer.
  */
-final class DomainDenormalizer implements NormalizerInterface, DenormalizerInterface, SerializerAwareInterface, CacheableSupportsMethodInterface
+final class DomainDenormalizer implements NormalizerInterface, DenormalizerInterface, SerializerAwareInterface
 {
     /**
      * @var ObjectNormalizer
@@ -32,7 +31,7 @@ final class DomainDenormalizer implements NormalizerInterface, DenormalizerInter
         $this->dispatcher = $dispatcher;
     }
 
-    public function denormalize($data, $class, $format = null, array $context = [])
+    public function denormalize($data, $class, $format = null, array $context = []): mixed
     {
         $domain = $this->decorated->denormalize($data, $class, $format, $context);
 
@@ -48,10 +47,7 @@ final class DomainDenormalizer implements NormalizerInterface, DenormalizerInter
         return $this->decorated->supportsDenormalization($data, $type, $format, $context);
     }
 
-    /**
-     * @return array|string|int|float|bool|\ArrayObject|null
-     */
-    public function normalize($object, $format = null, array $context = [])
+    public function normalize($object, $format = null, array $context = []): array|string|int|float|bool|\ArrayObject|null
     {
         return $this->decorated->normalize($object, $format, $context);
     }
@@ -68,8 +64,8 @@ final class DomainDenormalizer implements NormalizerInterface, DenormalizerInter
         }
     }
 
-    public function hasCacheableSupportsMethod(): bool
+    public function getSupportedTypes(?string $format): array
     {
-        return true;
+        return $this->decorated->getSupportedTypes($format);
     }
 }


### PR DESCRIPTION
Since PHP 8.1 is required for this bundle to work, it also means that the full support of Symfony 5.4 cannot be done anymore (it should be compatible with PHP 7.4 for this to work).

Therefore the next minor version will not be compatible with Symfony 5.4 anymore.